### PR TITLE
Fix DO (Dominican Republic) country

### DIFF
--- a/src/Geography/Country.php
+++ b/src/Geography/Country.php
@@ -19,7 +19,7 @@ class Country implements ValueObjectInterface
     public static function fromNative()
     {
         $codeString = \func_get_arg(0);
-        $code       = CountryCode::getByName($codeString);
+        $code       = CountryCode::get($codeString);
         $country    = new static($code);
 
         return $country;

--- a/src/Geography/CountryCodeName.php
+++ b/src/Geography/CountryCodeName.php
@@ -70,6 +70,7 @@ class CountryCodeName
         'DK' => 'Denmark',
         'DJ' => 'Djibouti',
         'DM' => 'Dominica',
+        'DO' => 'Dominican Republic',
         'DO_' => 'Dominican Republic',
         'EC' => 'Ecuador',
         'EG' => 'Egypt',

--- a/tests/Geography/CountryTest.php
+++ b/tests/Geography/CountryTest.php
@@ -48,4 +48,12 @@ class CountryTest extends TestCase
         $italy = new Country(CountryCode::IT());
         $this->assertSame('Italy', $italy->__toString());
     }
+
+    public function testFromNativeForCountryWithCodeAsReservedKeyword()
+    {
+        $fromNativeCountry  = Country::fromNative('DO');
+        $constructedCountry = new Country(CountryCode::DO_());
+
+        $this->assertTrue($constructedCountry->sameValueAs($fromNativeCountry));
+    }
 }


### PR DESCRIPTION
Because "do" is reserved keyword in PHP, the country used "DO_" as a constant in CountryCode, so when we initialize Country with "DO", we get an error.

This commit changes behavior of Country to use ::get() method on enum instead of ::getByName()